### PR TITLE
feat: Add validator to DeletePaymentFrequency Request

### DIFF
--- a/SysCredit.Api/Constants/ErrorCodePrefix.cs
+++ b/SysCredit.Api/Constants/ErrorCodePrefix.cs
@@ -43,6 +43,11 @@ public static class ErrorCodePrefix
     public const string ReferenceServicePrefix = $"{SERV}R";
 
     /// <summary>
+    ///     Prefijo para la clase: <see cref="LoanService"/>
+    /// </summary>
+    public const string LoanServicePrefix = $"{SERV}L";
+
+    /// <summary>
     ///     Prefijo para la clase: <see cref="RelationshipService" />
     /// </summary>
     public const string RelationshipServicePrefix = $"{SERV}RS";
@@ -83,6 +88,11 @@ public static class ErrorCodePrefix
     ///     Prefijo para la clase: <see cref="ReferenceStore" />
     /// </summary>
     public const string ReferenceStorePrefix = $"{DATA}R";
+
+    /// <summary>
+    ///     Prefijo para la clase: <see cref="LoanStore"/>
+    /// </summary>
+    public const string LoanStorePrefix = $"{DATA}L";
 
     /// <summary>
     ///     Prefijo para la clase: <see cref="RelationshipStore" />

--- a/SysCredit.Api/Extensions/ValidatorExtensions.cs
+++ b/SysCredit.Api/Extensions/ValidatorExtensions.cs
@@ -11,6 +11,7 @@ using SysCredit.Api.Validations.Authentications.Roles;
 using SysCredit.Api.Validations.Authentications.Users;
 using SysCredit.Api.Validations.Customers;
 using SysCredit.Api.Validations.Guarantors;
+using SysCredit.Api.Validations.Loans;
 using SysCredit.Api.Validations.LoanTypes;
 using SysCredit.Api.Validations.PaymentFrequencies;
 using SysCredit.Api.Validations.References;
@@ -95,4 +96,7 @@ public static partial class ValidatorExtensions
 
     public static IRuleBuilderOptions<T, long?> VeryfyIfExistsCustomerByGuarantorIdAsync<T>(this IRuleBuilder<T, long?> RuleBuilder)
         => RuleBuilder.SetAsyncValidator(new AsyncVerifyifCustomerByGuarantorIdValidator<T>());
+
+    public static IRuleBuilderOptions<T, long?> VeryfyIfExistsLoanByPaymentFrequencyIdAsync<T>(this IRuleBuilder<T, long?>RulerBuilder)
+        => RulerBuilder.SetAsyncValidator(new AsyncVerifyifExistLoanByPaymentFrequencyIdValidator<T>());
 }

--- a/SysCredit.Api/Properties/ErrorCodeMessages.es-NI.resx
+++ b/SysCredit.Api/Properties/ErrorCodeMessages.es-NI.resx
@@ -237,6 +237,9 @@
     <value>El id de la ruta y del request no coinciden</value>
     <comment>Errores Especificos: IService&lt;PaymentFrequency&gt;</comment>
   </data>
+  <data name="SERVPF0103" xml:space="preserve">
+    <value>Error, frequencia de pago en uso</value>
+  </data>
   <data name="SERVRS0000" xml:space="preserve">
     <value>Sin errores</value>
     <comment>Errores Generales: IService&lt;Relationship&gt;</comment>

--- a/SysCredit.Api/Properties/ErrorCodeMessages.resx
+++ b/SysCredit.Api/Properties/ErrorCodeMessages.resx
@@ -236,6 +236,9 @@
     <value>The route id doesn't match the request id</value>
     <comment>Errores Especificos: IService&lt;PaymentFrequency&gt;</comment>
   </data>
+  <data name="SERVPF0103" xml:space="preserve">
+    <value>Error, payment frequency in use</value>
+  </data>
   <data name="SERVRS0000" xml:space="preserve">
     <value>Success</value>
     <comment>Errores Generales: IService&lt;Relationship&gt;</comment>

--- a/SysCredit.Api/Requests/Loans/LoanIdRequest.cs
+++ b/SysCredit.Api/Requests/Loans/LoanIdRequest.cs
@@ -1,0 +1,16 @@
+﻿namespace SysCredit.Api.Requests.Loans;
+/// <summary>
+///     Representa una petición de busqueda por <see cref="LoanId"/> y <see cref="PaymentFrequencyId"/>.
+/// </summary>
+public class LoanIdRequest
+{
+    /// <summary>
+    ///     Id de registro del Prestamo que se buscara.
+    /// </summary>
+    public long? LoanId { get; set; }   
+
+    /// <summary>
+    ///     Id de la Frequency de pago que se buscara.
+    /// </summary>
+    public long? PaymentFrequencyId { get; set;}
+}

--- a/SysCredit.Api/Requests/PaymentFrequencies/DeletePaymentFrequencyRequest.cs
+++ b/SysCredit.Api/Requests/PaymentFrequencies/DeletePaymentFrequencyRequest.cs
@@ -12,5 +12,5 @@ public class DeletePaymentFrequencyRequest : IRequest
     /// <summary>
     ///     Propiedad que representa el Id de la frecuencia de pago.
     /// </summary>
-    public long PaymentFrequencyId { get; set; }
+    public long? PaymentFrequencyId { get; set; }
 }

--- a/SysCredit.Api/Services/PaymentFrequencyService.cs
+++ b/SysCredit.Api/Services/PaymentFrequencyService.cs
@@ -17,23 +17,23 @@ using static Constants.ErrorCodePrefix;
 using static SysCredit.Helpers.ContextData;
 
 /// <summary>
-///     Realiza distintas operaciones sobre <see cref="PaymentFrequency"/> como: Crear, Borrar, Buscar, Editar, etc
+///     Realiza distintas operaciones sobre <see cref="PaymentFrequency"/> como: Crear, Borrar, Buscar, Editar, etc.
 /// </summary>
 /// <param name="PaymentFrequencyStore">
-///     Tienda de datos para <see cref="PaymentFrequency"/>
+///     Tienda de datos para <see cref="PaymentFrequency"/>.
 /// </param>
 /// <param name="Logger"></param>
 [Service<IPaymentFrequencyService>]
 [ServiceModel<PaymentFrequency>]
 [ErrorCategory(nameof(PaymentFrequencyService))]
 [ErrorCodePrefix(PaymentFrequencyServicePrefix)]
-public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFrequencyStore)
+public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFrequencyStore, IStore<Loan> LoanStore)
 {
     /// <summary>
-    ///     Obtiene todos los <see cref="PaymentFrequency"/>
+    ///     Obtiene todos los <see cref="PaymentFrequency"/>.
     /// </summary>
     /// <returns>
-    ///     Regresa todos los <see cref="PaymentFrequency"/>
+    ///     Regresa todos los <see cref="PaymentFrequency"/>.
     /// </returns>
     [MethodId("F454CC3B-23ED-4A4E-B27E-5E6377CA3B5D")]
     public IAsyncEnumerable<PaymentFrequencyInfo> FetchPaymentFrequencyAsync()
@@ -42,13 +42,13 @@ public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFre
     }
 
     /// <summary>
-    ///     Obtiene un registro de la tabla <see cref="Models.PaymentFrequency"/>
+    ///     Obtiene un registro de la tabla <see cref="Models.PaymentFrequency"/>.
     /// </summary>
     /// <param name="PaymentFrequencyId">
-    ///     Id obtenido de la ruta
+    ///     Id obtenido de la ruta.
     /// </param>
     /// <returns>
-    ///     Regresa un registro de la tabla <see cref="Models.PaymentFrequency"/>
+    ///     Regresa un registro de la tabla <see cref="Models.PaymentFrequency"/>.
     /// </returns>
     [MethodId("F2625C55-FCD9-4FEF-AAA0-3782B91A819B")]
     public async ValueTask<PaymentFrequencyInfo?> FetchPaymentFrequencyByIdAsync(long PaymentFrequencyId)
@@ -57,16 +57,16 @@ public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFre
     }
 
     /// <summary>
-    ///     Validad e invoca al Store para modificar la frequencia de pago
+    ///     Validad e invoca al Store para modificar la frequencia de pago.
     /// </summary>
     /// <param name="PaymentFrequencyId">
-    ///     Id recibido de la ruta
+    ///     Id recibido de la ruta.
     /// </param>
     /// <param name="Request">
-    ///     Datos que se van a actualizar del <see cref="Models.PaymentFrequency"/>
+    ///     Datos que se van a actualizar del <see cref="Models.PaymentFrequency"/>.
     /// </param>
     /// <returns>
-    ///     Retorna un bool
+    ///     Retorna un bool.
     /// </returns>
     [MethodId("54EA25C1-FD73-4FC3-8984-DEA6ACFD74C7")]
     public async ValueTask<bool> UpdatePaymentFrequencyAsync(long PaymentFrequencyId, UpdatePaymentFrequencyRequest Request)
@@ -79,26 +79,28 @@ public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFre
     }
 
     /// <summary>
-    ///     Valida e invoca al Store para eliminar la frecuencia de pago
+    ///     Valida e invoca al Store para eliminar la frecuencia de pago.
     /// </summary>
     /// <param name="Request">
-    ///      Id del <see cref="Models.PaymentFrequency"/> a eliminar 
+    ///      Id del <see cref="Models.PaymentFrequency"/> a eliminar .
     /// </param>
     /// <returns>
-    ///     Retorna un bool
+    ///     Retorna un bool.
     /// </returns>
     [MethodId("FDB8109F-DF96-48B7-8B60-F233F2A8098F")]
     public async ValueTask<bool> DeletePaymentFrequencyAsync(DeletePaymentFrequencyRequest Request)
     {
-        await Request.ValidateAndThrowOnFailuresAsync(Key(nameof(PaymentFrequencyStore)).Value(PaymentFrequencyStore));
+        await Request.ValidateAndThrowOnFailuresAsync(Key(nameof(LoanStore)).Value(LoanStore)
+                                                     .Key(nameof(PaymentFrequencyStore)).Value(PaymentFrequencyStore));
+       
         return await PaymentFrequencyStore.DeletePaymentFrequencyAsync(Request);
     }
 
     /// <summary>
-    ///      Obtiene todos los registros completos de la tabla <see cref="Models.PaymentFrequency"/>
+    ///      Obtiene todos los registros completos de la tabla <see cref="Models.PaymentFrequency"/>.
     /// </summary>
     /// <returns>
-    ///      Regresa todos los registros completos de la tabla <see cref="Models.PaymentFrequency"/>
+    ///      Regresa todos los registros completos de la tabla <see cref="Models.PaymentFrequency"/>.
     /// </returns>
     [MethodId("6006B8FC-E3F7-43E4-9E70-6E6CA69053B0")]
     public IAsyncEnumerable<PaymentFrequency> FetchPaymentFrequencyCompleteAsync()
@@ -107,13 +109,13 @@ public partial class PaymentFrequencyService(IStore<PaymentFrequency> PaymentFre
     }
 
     /// <summary>
-    ///     Valida y crea una nueva frecuencia de pago en la base de datos
+    ///     Valida y crea una nueva frecuencia de pago en la base de datos.
     /// </summary>
     /// <param name="Request">
-    ///     Datos usado para crear la frecuencia de pago
+    ///     Datos usado para crear la frecuencia de pago.
     /// </param>
     /// <returns>
-    ///     Regresa el nuevo Id de la frecuencia de pago creado
+    ///     Regresa el nuevo Id de la frecuencia de pago creado.
     /// </returns>
     [MethodId("BC663C2B-ACE2-499B-B806-2A0BD8D77815")]
     public async ValueTask<EntityId> InsertPaymentFrequencyAsync(CreatePaymentFrequencyRequest Request)

--- a/SysCredit.Api/Stores/LoanStore.cs
+++ b/SysCredit.Api/Stores/LoanStore.cs
@@ -1,0 +1,34 @@
+﻿namespace SysCredit.Api.Stores;
+
+using SysCredit.Api.Attributes;
+using SysCredit.Api.Extensions;
+using SysCredit.DataTransferObject.Commons;
+using SysCredit.Models;
+using static Constants.ErrorCodePrefix;
+
+/// <summary>
+///     Repositorio del modelo <see cref="Loan"/>.
+/// </summary>
+[Store]
+[ErrorCategory(nameof(LoanStore))]
+[ErrorCodePrefix(LoanStorePrefix)]
+public static partial class LoanStore
+{
+    /// <summary>
+    ///     Recupera información sobre un préstamo basado en su frecuencia de pago.
+    /// </summary>
+    /// <param name="Store">
+    ///     Repositorio de Loan.
+    /// </param>
+    /// <param name="PaymentFrequencyId">
+    ///     Id de la Frequencia de pago.
+    /// </param>
+    /// <returns>
+    ///     Retorna la Frequencia de pago.
+    /// </returns>
+    [MethodId("5CE05A0D-F8DE-4BC0-8963-B621C63FF1B9")]
+    public static async ValueTask<LoanInfo?> FetchLoanByPaymentFrequencyIdAsync(this IStore<Loan> Store, long? PaymentFrequencyId)
+    {
+        return await Store.ExecuteStoredProcedureQueryFirstOrDefaultValueAsync<LoanInfo?>("[dbo].[FetchLoanByPaymentFrequencyId]", new { PaymentFrequencyId });
+    }
+}

--- a/SysCredit.Api/Validations/Loans/AsyncVerifyifExistLoanByPaymentFrequencyIdValidator.cs
+++ b/SysCredit.Api/Validations/Loans/AsyncVerifyifExistLoanByPaymentFrequencyIdValidator.cs
@@ -1,0 +1,57 @@
+﻿namespace SysCredit.Api.Validations.Loans;
+
+using FluentValidation;
+using FluentValidation.Validators;
+using SysCredit.Api.Extensions;
+using SysCredit.Api.Properties;
+using SysCredit.Api.Stores;
+using SysCredit.Models;
+
+/// <summary>
+///     Validador que verifica si un Prestamo Tiene Frequencia de Pago.
+/// </summary>
+/// <typeparam name="T">
+///     Tipo de Request que se va a Validar.
+/// </typeparam>
+public class AsyncVerifyifExistLoanByPaymentFrequencyIdValidator<T> : AsyncPropertyValidator<T, long?>
+{
+    /// <summary>
+    ///     Valida si el Prestamo Tiene uan Frequencia de pago.
+    /// </summary>
+    /// <param name="Context">
+    ///     Contiene información del Request que se Esta validando
+    /// </param>
+    /// <param name="PaymentFrequencyId">
+    ///     Id del Cliente que se Valida.
+    /// </param>
+    /// <param name="Cancellation">
+    ///     Método que detiene la Validacion.
+    /// </param>
+    /// <returns>
+    ///     Retorna true la frecuencia de pago no está siendo utilizada.
+    /// </returns>
+    public override async Task<bool> IsValidAsync(ValidationContext<T> Context, long? PaymentFrequencyId, CancellationToken Cancellation)
+    {
+        var Loan = await Context.RootContextData[nameof(LoanStore)].AsStore<Loan>().FetchLoanByPaymentFrequencyIdAsync(PaymentFrequencyId);
+        return Loan is null;
+    }
+
+    /// <summary>
+    ///     Lanza el error del validador.
+    /// </summary>
+    /// <param name="ErrorCode">
+    ///     Codigo de Error asignado.
+    /// </param>
+    /// <returns>
+    ///     Retorna el mensaje de Error aignado.
+    /// </returns>
+    protected override string GetDefaultMessageTemplate(string ErrorCode)
+    {
+        return ErrorCodeMessages.GetMessageFromCode(ErrorCode)!;
+    }
+
+    /// <summary>
+    ///     Nombre único del Validador.
+    /// </summary>
+    public override string Name => "AsyncVerifyifExistLoanByPaymentFrequencyIdValidator";
+}

--- a/SysCredit.Api/Validations/PaymentFrequencies/DeletePaymentFrequencyValidator.cs
+++ b/SysCredit.Api/Validations/PaymentFrequencies/DeletePaymentFrequencyValidator.cs
@@ -1,10 +1,10 @@
 ﻿namespace SysCredit.Api.Validations.PaymentFrequencies;
 
 using FluentValidation;
-
+using SysCredit.Api.Constants;
 using SysCredit.Api.Extensions;
 using SysCredit.Api.Requests.PaymentFrequencies;
-
+using SysCredit.Api.Constants;
 /// <summary>
 ///     Clase validadora de <see cref="DeletePaymentFrequencyRequest"/>.
 /// </summary>
@@ -16,7 +16,7 @@ public class DeletePaymentFrequencyValidator : AbstractValidator<DeletePaymentFr
     public DeletePaymentFrequencyValidator()
     {
         RuleFor(Pf => Pf.PaymentFrequencyId)
-            .NotNull()
+            .VeryfyIfExistsLoanByPaymentFrequencyIdAsync().WithErrorCode(ErrorCodes.SERVPF0103)
             .WithName("Frecuencia de pago");
     }
 }

--- a/SysCredit.Models/Loan.cs
+++ b/SysCredit.Models/Loan.cs
@@ -1,0 +1,93 @@
+﻿namespace SysCredit.Models;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+/// <summary>
+///     Modelo de la tabla Loan.
+/// </summary>
+public record class Loan : Entity
+{
+    /// <summary>
+    ///    Id de Prestamo. 
+    /// </summary>
+    public long LoanId { get; set; }
+
+    /// <summary>
+    ///     Id del Tipo de prestamo.
+    /// </summary>
+    public long LoanTypeId { get; set; }
+
+    /// <summary>
+    ///     Id de la Frequencia de pago.
+    /// </summary>
+    public long PaymentFrequencyId { get; set; }
+    
+    /// <summary>
+    ///     Id del Cliente
+    /// </summary>
+    public long CustomerId { get; set; }
+
+    /// <summary>
+    ///     Monto del préstamo.
+    /// </summary>
+    public decimal LoanAmount { get; set; }
+
+    /// <summary>
+    ///     Cantidad de pagos programados.
+    /// </summary>
+    public int QtyPayments { get; set; }
+
+    /// <summary>
+    ///     Valor de cada pago programado.
+    /// </summary>
+    public decimal PaymentValue { get; set; }
+
+    /// <summary>
+    ///     Valor del primer pago programado.
+    /// </summary>
+    public decimal FirstPaymentValue { get; set; }
+
+    /// <summary>
+    ///     Tasa de interés del préstamo.
+    /// </summary>
+    public decimal LoanRate { get; set; }
+
+    /// <summary>
+    ///     Monto total del préstamo incluyendo intereses.
+    /// </summary>
+    public decimal TotalLoanAmount { get; set; }
+
+    /// <summary>
+    ///     Monto del pago diario.
+    /// </summary>
+    public decimal PaymentAmountPerDay { get; set; }
+
+    /// <summary>
+    ///     Monto del pago mensual.
+    /// </summary>
+    public decimal PaymentAmountPerMonth { get; set; }
+
+    /// <summary>
+    ///     Fecha de la primera visita o pago programado.
+    /// </summary>
+    public DateTime DateFirstVisit { get; set; }
+
+    /// <summary>
+    ///     Fecha de finalización del pago del préstamo.
+    /// </summary>
+    public DateTime DateEndPayment { get; set; }
+
+    /// <summary>
+    ///     Notas o comentarios adicionales.
+    /// </summary>
+    public string Notes { get; set; } = String.Empty;
+
+    /// <summary>
+    ///     Fecha en que se otorgó el préstamo.
+    /// </summary>
+    public DateTime LoanDate { get; set; }
+}

--- a/SysCredit.SQLServer/StoredProcedures/Loans/FetchLoanByPaymentFrequencyId.sql
+++ b/SysCredit.SQLServer/StoredProcedures/Loans/FetchLoanByPaymentFrequencyId.sql
@@ -1,0 +1,8 @@
+﻿CREATE PROCEDURE [dbo].[FetchLoanByPaymentFrequencyId]
+	@PaymentFrequencyId BIGINT
+AS
+BEGIN
+	SELECT * FROM [dbo].[Loan]
+	WHERE [IsDelete] = 0 AND [PaymentFrequencyId] = @PaymentFrequencyId
+END
+GO

--- a/SysCredit.SQLServer/SysCredit.SQLServer.sqlproj
+++ b/SysCredit.SQLServer/SysCredit.SQLServer.sqlproj
@@ -71,6 +71,7 @@
     <Folder Include="StoredProcedures\Catalogs\LoanTypes" />
     <Folder Include="StoredProcedures\Catalogs\Relationships" />
     <Folder Include="StoredProcedures\Catalogs\PaymentFrequencies" />
+    <Folder Include="StoredProcedures\Loans" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Tables\Customer.sql" />
@@ -152,6 +153,7 @@
     <Build Include="StoredProcedures\Catalogs\Relationships\InsertRelationship.sql" />
     <Build Include="StoredProcedures\Catalogs\Relationships\DeleteRelationship.sql" />
     <Build Include="StoredProcedures\Customers\FetchCustomerByGuarantorId.sql" />
+    <Build Include="StoredProcedures\Loans\FetchLoanByPaymentFrequencyId.sql" />
   </ItemGroup>
   <ItemGroup>
     <ArtifactReference Include="$(DacPacRootPath)\Extensions\Microsoft\SQLDB\Extensions\SqlServer\AzureV12\SqlSchemas\master.dacpac">


### PR DESCRIPTION
- [X] .Se debe validar que el `PaymentFrequency` no esté siendo utilizado por la tabla `Loan`.

- [X] .Se debe asignar un codigo de error unico al validador y luego agregar su mensaje de error.

  Prefijo: `SERVPF`.

- [X] . Los mensajes de error van en el archivo `ErrorCodeMessages`, se deben agregar en español y en ingles.